### PR TITLE
fix: prevent rate limiter quota consumption on empty queue (#4)

### DIFF
--- a/src/core/CHANGELOG.md
+++ b/src/core/CHANGELOG.md
@@ -4,6 +4,23 @@ Changes to the core module: `QueueClient`, `Queue`, `Job`, `Worker`, `backoff`, 
 
 ---
 
+## [1.0.2] — 2026-09-04
+
+### Fixed
+
+- **`Worker` — rate-limit quota no longer consumed on empty-queue polls** ([#4](https://github.com/rafidahmed870/queue-jobs-worker/issues/4))
+
+  `claimNext()` previously called `checkAndIncrementRateLimit()` before
+  attempting to claim a job. This meant every poll cycle against an empty queue
+  burned a quota slot, potentially exhausting the configured window budget
+  before any real work was done. After the fix, the storage `claim()` call
+  happens first; the rate-limit counter is only incremented when a job is
+  actually claimed for processing. If the rate limit is reached at that point
+  the lock is immediately released via `releaseLock()` so the job remains
+  reclaimable on the next window.
+
+---
+
 ## [1.0.1] — 2026-08-31
 
 ### Fixed
@@ -47,5 +64,6 @@ Changes to the core module: `QueueClient`, `Queue`, `Job`, `Worker`, `backoff`, 
 ---
 
 <!-- Links -->
+[1.0.2]: https://github.com/rafidahmed870/queue-jobs-worker/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/rafidahmed870/queue-jobs-worker/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/rafidahmed870/queue-jobs-worker/releases/tag/v1.0.0

--- a/src/core/worker.ts
+++ b/src/core/worker.ts
@@ -208,17 +208,9 @@ export class Worker {
   private async claimNext(): Promise<boolean> {
     const now = new Date().toISOString();
 
-    // Rate-limit check (if configured).
-    if (this.config.rateLimit) {
-      const allowed = await this.storage.checkAndIncrementRateLimit(
-        this.queueName,
-        this.config.rateLimit.max,
-        this.config.rateLimit.duration,
-        now,
-      );
-      if (!allowed) return false;
-    }
-
+    // Attempt to claim a job before touching the rate-limit counter.
+    // The counter must only be consumed when a job is actually claimed for
+    // processing — polling an empty queue must not burn quota (issue #4).
     const raw = await this.storage.claim({
       queue: this.queueName,
       lockId: this.id,
@@ -227,6 +219,22 @@ export class Worker {
     });
 
     if (!raw) return false;
+
+    // A job was claimed. Now enforce the rate limit.  If the limit has been
+    // reached we immediately release the lock so the job is recoverable and
+    // return false — the poll loop will stop trying until the next cycle.
+    if (this.config.rateLimit) {
+      const allowed = await this.storage.checkAndIncrementRateLimit(
+        this.queueName,
+        this.config.rateLimit.max,
+        this.config.rateLimit.duration,
+        now,
+      );
+      if (!allowed) {
+        await this.storage.releaseLock(raw.id);
+        return false;
+      }
+    }
 
     const job = new Job(raw);
     this.activeCount += 1;

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -184,6 +184,48 @@ describe("Worker", () => {
     await adapter.close();
   });
 
+  it("rate limit quota is not consumed when the queue is empty", async () => {
+    // Regression test for: rate-limit counter incremented on every poll cycle
+    // even when no jobs are available, exhausting the quota before any real
+    // work is done (issue #4).
+    //
+    // Strategy: configure a limit of 2 jobs per 10-second window and let the
+    // worker poll an empty queue several times.  Then enqueue 2 jobs and
+    // verify both are processed — if the bug were present the quota would
+    // already be exhausted and neither job would run.
+    const { InMemoryStorageAdapter } = await import("../src/storage/in-memory.adapter.js");
+    const adapter = new InMemoryStorageAdapter();
+    await adapter.initialize();
+
+    client = new QueueClient({
+      adapter,
+      defaults: { pollInterval: 30 },
+    });
+
+    const queue = client.createQueue("rate-limit-empty-test", {
+      rateLimit: { max: 2, duration: 10_000 },
+    });
+
+    const processed = vi.fn();
+    queue.process("task", async () => {
+      processed();
+    });
+
+    // Start the worker with an empty queue and let it poll several times,
+    // which would exhaust the quota under the old (buggy) implementation.
+    const worker = queue.createWorker({ concurrency: 2 });
+    await sleep(200); // ~6 poll cycles with no jobs
+
+    // Now add 2 jobs — both should be processed within the same rate-limit
+    // window because no quota was consumed during the empty polls.
+    await queue.enqueue("task", {});
+    await queue.enqueue("task", {});
+    await sleep(300);
+
+    expect(processed).toHaveBeenCalledTimes(2);
+    await worker.stop();
+  });
+
   it("emits job:failed on processor error", async () => {
     client = new QueueClient({ defaults: { pollInterval: 50 } });
     const queue = client.createQueue("fail-event");


### PR DESCRIPTION
Description

Fix rate limiter quota being consumed when polling an empty queue.

Changes
Only consume quota after successfully claiming a job.
Add a regression test for empty-queue polling.

Fixes #4