### PR TITLE
fix(worker): cancel timed-out processor execution via AbortSignal (#12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,33 @@ All notable changes to **queue-jobs-worker** will be documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] — 2026-09-09
+
+### Core
+
+### Fixed
+
+- **`Worker` — Job timeout cooperative cancellation via `AbortSignal`** ([#12](https://github.com/rafidahmed870/queue-jobs-worker/issues/12))
+
+  Previously, when a job attempt reached its configured `timeout`, the worker rejected the internal execution promise and marked the attempt as failed (or scheduled a retry), but the underlying processor `Promise` continued running in the background. This could lead to duplicate side effects when retries overlapped with timed-out attempts.
+
+  After the fix:
+
+  - `Processor` type signature is updated: `type Processor<TPayload = unknown> = (job: Job<TPayload>, signal: AbortSignal) => Promise<void>`.
+  - An `AbortController` is created for each job attempt.
+  - When job execution times out, the worker aborts the `AbortSignal` with a timeout error before rejecting the wrapper promise.
+  - User processors can monitor `signal.aborted` or pass `signal` to async operations (e.g. `fetch`, database queries, timers) for cooperative cancellation.
+
+### Package
+
+### Fixed
+
+- **`package.json` — Added `assets` to npm package `files` distribution**
+
+  Added `"assets"` to the `"files"` list in `package.json` so header banner graphics in `README.md` display properly on npmjs.com.
+
 ---
+
 ## [1.0.2] — 2026-09-05
 
 ### Core
@@ -122,7 +148,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- Links -->
 
-[1.0.2]: https://github.com/rafidahmed870/queue-jobs-worker/compare/v1.0.0...v1.0.2
+[1.0.3]: https://github.com/rafidahmed870/queue-jobs-worker/compare/v1.0.2...v1.0.3
+[1.0.2]: https://github.com/rafidahmed870/queue-jobs-worker/compare/v1.0.1...v1.0.2
 [1.0.0]: https://github.com/rafidahmed870/queue-jobs-worker/releases/tag/v1.0.0
 [1.0.1]: https://github.com/rafidahmed870/queue-jobs-worker/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/rafidahmed870/queue-jobs-worker/releases/tag/v1.0.0

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -83,17 +83,20 @@ Helper methods: `isActive()`, `isCompleted()`, `isWaiting()`, `isDelayed()`, `is
 
 ## User-Defined Processors
 
-Business logic is kept entirely outside the library. Processors are async functions registered per job type:
+Business logic is kept entirely outside the library. Processors are async functions registered per job type that receive the `Job` instance and an `AbortSignal`:
 
 ```ts
-emails.process("send-email", async (job) => {
-  await sendEmail(job.data.to, job.data.subject);
+emails.process("send-email", async (job, signal) => {
+  await sendEmail(job.data.to, job.data.subject, { signal });
   // Return  → job marked completed
   // Throw   → job marked failed (triggers retry or DLQ)
 });
 ```
 
 Multiple job types can be registered on the same queue. Each type has its own processor function.
+
+### Cooperative Cancellation on Timeout
+When a per-attempt job `timeout` is reached, the worker aborts the `signal` associated with that execution attempt. Because Node.js cannot forcibly terminate running promises, processors must cooperate with cancellation by passing `signal` to abortable APIs or checking `signal.aborted` during long-running tasks.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -240,18 +240,24 @@ If you want TypeScript type safety for `job.data`, pass a generic when creating 
 
 ## Processing Jobs
 
-Register a processor before creating or starting a worker:
+Register a processor before creating or starting a worker. Processors receive the `job` instance as well as an `AbortSignal` for cooperative cancellation when a job attempt times out:
 
 ```js
-queue.process("send-push", async (job) => {
+queue.process("send-push", async (job, signal) => {
   const { userId } = job.data;
 
-  await pushService.send(userId, "You have a new message");
+  // Pass signal to APIs that support cancellation (e.g. fetch, DB queries):
+  await pushService.send(userId, "You have a new message", { signal });
+
+  // Or check signal.aborted before performing expensive steps:
+  if (signal.aborted) return;
 
   // Return to mark the job complete.
   // Throw any error to trigger retry logic or DLQ handling.
 });
 ```
+
+> **Note on Timeout Cancellation**: In Node.js, asynchronous operations cannot be forcibly terminated from the outside. Processors should cooperate with cancellation by checking `signal.aborted` or forwarding `signal` to abortable APIs to ensure timed-out executions do not continue running in the background.
 
 See [FEATURES.md](./FEATURES.md) for the full `job` model and helper methods.
 
@@ -506,7 +512,7 @@ Creates a client using a custom storage backend.
 
 ### `queue.process(type, processor)`
 
-Registers an async processor for a job type.
+Registers an async processor for a job type. The processor signature is `async (job, signal) => ...`, where `signal` is an `AbortSignal` aborted when the per-attempt timeout is reached.
 
 ### `queue.createWorker(options?)`
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -247,12 +247,12 @@ The package does not implement job-specific business logic.
 Users register processors for their job types.
 
 ```ts
-emails.process("send-email", async (job) => {
-  await sendEmail(job.data);
+emails.process("send-email", async (job, signal) => {
+  await sendEmail(job.data, { signal });
 });
 ```
 
-The worker executes the processor and manages its execution lifecycle.
+The worker executes the processor with an `AbortSignal` for cooperative cancellation on timeout and manages its execution lifecycle.
 
 ### Worker Concurrency
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "queue-jobs-worker",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "queue-jobs-worker",
-      "version": "1.0.1",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "croner": "^10.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "queue-jobs-worker",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Reliable job queue and background worker system for Node.js with retries, concurrency, scheduling, and failure recovery.",
   "keywords": [
     "queue-jobs-worker",
@@ -49,6 +49,7 @@
   "sideEffects": false,
   "files": [
     "dist",
+    "assets",
     "README.md",
     "CHANGELOG.md",
     "LICENSE"

--- a/src/core/CHANGELOG.md
+++ b/src/core/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 Changes to the core module: `QueueClient`, `Queue`, `Job`, `Worker`, `backoff`, and `id` utilities.
 
+## [1.0.3] — 2026-09-09
+
+### Fixed
+
+- **`Worker` — Job timeout cooperative cancellation via `AbortSignal`** ([#12](https://github.com/rafidahmed870/queue-jobs-worker/issues/12))
+
+  Previously, when a job attempt reached its configured `timeout`, the worker rejected the internal execution promise and marked the attempt as failed (or scheduled a retry), but the underlying processor `Promise` continued running in the background. This could lead to duplicate side effects when retries overlapped with timed-out attempts.
+
+  After the fix:
+
+  - `Processor` type signature is updated: `type Processor<TPayload = unknown> = (job: Job<TPayload>, signal: AbortSignal) => Promise<void>`.
+  - An `AbortController` is created for each job attempt.
+  - When job execution times out, the worker aborts the `AbortSignal` with a timeout error before rejecting the wrapper promise.
+  - User processors can monitor `signal.aborted` or pass `signal` to async operations (e.g. `fetch`, database queries, timers) for cooperative cancellation.
+
 ---
 
 ## [1.0.2] — 2026-09-05
@@ -87,6 +102,7 @@ Changes to the core module: `QueueClient`, `Queue`, `Job`, `Worker`, `backoff`, 
 ---
 
 <!-- Links -->
+[1.0.3]: https://github.com/rafidahmed870/queue-jobs-worker/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/rafidahmed870/queue-jobs-worker/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/rafidahmed870/queue-jobs-worker/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/rafidahmed870/queue-jobs-worker/releases/tag/v1.0.0

--- a/src/core/worker.ts
+++ b/src/core/worker.ts
@@ -261,6 +261,7 @@ export class Worker {
       return;
     }
 
+    const abortController = new AbortController();
     let timeoutHandle: NodeJS.Timeout | null = null;
     let lockRenewTimer: NodeJS.Timeout | null = null;
 
@@ -281,10 +282,12 @@ export class Worker {
       await new Promise<void>((resolve, reject) => {
         // Enforce per-attempt timeout.
         timeoutHandle = setTimeout(() => {
-          reject(new Error(`Job timed out after ${job.timeout}ms`));
+          const timeoutError = new Error(`Job timed out after ${job.timeout}ms`);
+          abortController.abort(timeoutError);
+          reject(timeoutError);
         }, job.timeout);
 
-        Promise.resolve(processor(job)).then(resolve, reject);
+        Promise.resolve(processor(job, abortController.signal)).then(resolve, reject);
       });
 
       // Success path.

--- a/src/types/worker.types.ts
+++ b/src/types/worker.types.ts
@@ -14,7 +14,10 @@ import type { Job } from "../core/job.js";
  * Must resolve to indicate success.
  * Throwing (or rejecting) marks the job as failed for this attempt.
  */
-export type Processor<TPayload = unknown> = (job: Job<TPayload>) => Promise<void>;
+export type Processor<TPayload = unknown> = (
+  job: Job<TPayload>,
+  signal: AbortSignal,
+) => Promise<void>;
 
 // ---------------------------------------------------------------------------
 // Worker options

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -511,3 +511,95 @@ describe("Worker — cron scheduling (issue #5)", () => {
     await worker2.stop();
   });
 });
+
+describe("Worker — job timeout cancellation (issue #12)", () => {
+  let client: QueueClient;
+
+  afterEach(async () => {
+    if (client) await client.close();
+  });
+
+  it("passes an AbortSignal as second argument to the processor", async () => {
+    client = new QueueClient({ defaults: { pollInterval: 30 } });
+    const queue = client.createQueue("signal-param-test");
+    let receivedSignal: AbortSignal | null = null;
+
+    queue.process("task", async (_job, signal) => {
+      receivedSignal = signal;
+    });
+
+    await queue.enqueue("task", {});
+    const worker = queue.createWorker();
+
+    await sleep(200);
+
+    expect(receivedSignal).toBeInstanceOf(AbortSignal);
+    expect(receivedSignal!.aborted).toBe(false);
+
+    await worker.stop();
+  });
+
+  it("aborts the AbortSignal when job timeout is reached", async () => {
+    client = new QueueClient({ defaults: { pollInterval: 30 } });
+    const queue = client.createQueue("timeout-abort-test", {
+      timeout: 100,
+      attempts: 1,
+    });
+
+    let signalAborted = false;
+    let abortReason: Error | null = null;
+
+    queue.process("slow-job", async (_job, signal) => {
+      signal.addEventListener("abort", () => {
+        signalAborted = true;
+        abortReason = signal.reason as Error;
+      });
+
+      // Sleep longer than the 100ms timeout
+      await sleep(300);
+    });
+
+    await queue.enqueue("slow-job", {}, { timeout: 100, attempts: 1 });
+    const worker = queue.createWorker();
+
+    await sleep(350);
+
+    expect(signalAborted).toBe(true);
+    expect(abortReason).toBeDefined();
+    expect(abortReason!.message).toContain("Job timed out after 100ms");
+
+    await worker.stop();
+  });
+
+  it("allows processor to cooperatively cancel background work on timeout", async () => {
+    client = new QueueClient({ defaults: { pollInterval: 30 } });
+    const queue = client.createQueue("cooperative-cancel-test", {
+      timeout: 100,
+      attempts: 2,
+      retryDelay: 100,
+    });
+
+    let backgroundTaskFinished = false;
+
+    queue.process("slow-job", async (_job, signal) => {
+      for (let i = 0; i < 10; i++) {
+        if (signal.aborted) {
+          // Cooperative cancellation exit
+          return;
+        }
+        await sleep(50);
+      }
+      backgroundTaskFinished = true;
+    });
+
+    await queue.enqueue("slow-job", {}, { timeout: 100, attempts: 1 });
+    const worker = queue.createWorker();
+
+    // Wait past timeout (100ms) and potential loop duration (500ms)
+    await sleep(600);
+
+    expect(backgroundTaskFinished).toBe(false);
+
+    await worker.stop();
+  });
+});


### PR DESCRIPTION
## Summary of Changes

### 1. Job Timeout Cooperative Cancellation (`AbortSignal`)
- **Updated `Processor` Type**: Modified `Processor<TPayload>` signature to accept an `AbortSignal` as the second argument:
  ```ts
  type Processor<TPayload = unknown> = (
    job: Job<TPayload>,
    signal: AbortSignal
  ) => Promise<void>;
  ```
- **Worker Timeout Signal Abort**: In `Worker.executeJob()`, an `AbortController` is created for each job attempt. When per-attempt `timeout` is reached, `abortController.abort(timeoutError)` is invoked before rejecting the execution wrapper Promise.
- **Prevents Duplicate Side Effects**: Processors can now cooperatively cancel ongoing background operations (e.g. passing `signal` to `fetch`, `setTimeout`, or checking `signal.aborted`), ensuring a timed-out attempt does not overlap with a retry.

### 2. NPM Package Asset Distribution Fix
- **Added `assets` to `package.json`**: Added `"assets"` to the `"files"` array in `package.json` to ensure header graphics (`assets/queue-jobs-worker-github.png`) render correctly when published on npm.

### 3. Version Bump & Release Documentation (v1.0.3)
- Bumped version in `package.json` from `1.0.2` to `1.0.3`.
- Updated release notes in `src/core/CHANGELOG.md` and root `CHANGELOG.md`.
- Updated `README.md`, `FEATURES.md`, and `docs/ARCHITECTURE.md` with guidelines on handling `AbortSignal` in job processors.

---

## Verification & Testing

All quality checks have passed cleanly:
- **Unit Tests**: Executed `npm test` (`vitest run`). All 43 test cases passed, including new test cases for `AbortSignal` receiving, timeout signal abort, and cooperative cancellation.
- **Type Checking**: Executed `npm run typecheck` (`tsc --noEmit`) with 0 errors.
- **Linting**: Executed `npm run lint` (`eslint .`) with 0 errors.
- **Build**: Executed `npm run build` (`tsup` + `tsc`) producing clean ESM (`dist/index.js`) and CJS (`dist/index.cjs`) bundles.

---

## Example Usage

```js
const queue = client.createQueue("test", {
  timeout: 1_000,
  attempts: 2,
  retryDelay: 100,
});

queue.process("slow-job", async (job, signal) => {
  console.log("processor started");

  // Pass signal to abortable APIs or check signal.aborted in loops
  if (signal.aborted) return;

  await fetch("https://api.example.com/long-task", { signal });

  console.log("processor finished");
});
```